### PR TITLE
fix:Add composables with TanstackQuery

### DIFF
--- a/src/composables/useElixirs.ts
+++ b/src/composables/useElixirs.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/vue-query'
+import axios from 'axios'
+import type { Elixir } from '@/types/Elixir'
+
+const fetchElixirs = async (): Promise<Elixir[]> => {
+  const { data } = await axios.get('https://wizard-world-api.herokuapp.com/Elixirs')
+  return data
+}
+
+export function useElixirs() {
+  return useQuery({
+    queryKey: ['elixirs'],
+    queryFn: fetchElixirs,
+    staleTime: 1000 * 60 * 5,
+  })
+}

--- a/src/composables/useHouses.ts
+++ b/src/composables/useHouses.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/vue-query'
+import axios from 'axios'
+import type { House } from '@/types/House'
+
+const API_BASE = 'https://wizard-world-api.herokuapp.com'
+
+const fetchHouses = async (): Promise<House[]> => {
+  const { data } = await axios.get(`${API_BASE}/Houses`)
+  return data
+}
+
+const fetchHouseById = async (id: string): Promise<House> => {
+  const { data } = await axios.get(`${API_BASE}/Houses/${id}`)
+  return data
+}
+
+export function useHouses() {
+  return useQuery({
+    queryKey: ['houses'],
+    queryFn: fetchHouses,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  })
+}
+
+export function useHouse(id: string) {
+  return useQuery({
+    queryKey: ['hosue', id],
+    queryFn: () => fetchHouseById(id),
+    enabled: !!id, // only fetch if id is defined
+    staleTime: 1000 * 60 * 10,
+  })
+}

--- a/src/composables/useIngredients.ts
+++ b/src/composables/useIngredients.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/vue-query'
+import axios from 'axios'
+import type { Elixir } from '@/types/Elixir'
+
+const fetchElixirs = async (): Promise<Elixir[]> => {
+  const { data } = await axios.get('https://wizard-world-api.herokuapp.com/Ingredients')
+  return data
+}
+
+export function useElixirs() {
+  return useQuery({
+    queryKey: ['elixirs'],
+    queryFn: fetchElixirs,
+    staleTime: 1000 * 60 * 5,
+  })
+}

--- a/src/composables/useSpells.ts
+++ b/src/composables/useSpells.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/vue-query'
+import axios from 'axios'
+import type { Spell } from '@/types/Spell'
+
+const fetchSpells = async (): Promise<Spell[]> => {
+  const { data } = await axios.get('https://wizard-world-api.herokuapp.com/Spells')
+  return data
+}
+
+export function useSpells() {
+  return useQuery({
+    queryKey: ['spells'],
+    queryFn: fetchSpells,
+    staleTime: 1000 * 60 * 5,
+  })
+}

--- a/src/composables/useWizards.ts
+++ b/src/composables/useWizards.ts
@@ -1,0 +1,38 @@
+import { useQuery, useQueryClient } from '@tanstack/vue-query'
+import axios from 'axios'
+import type { Wizard } from '@/types/Wizard'
+
+const API_BASE = 'https://wizard-world-api.herokuapp.com'
+
+const fetchWizards = async (): Promise<Wizard[]> => {
+  const { data } = await axios.get(`${API_BASE}/Wizards`)
+  return data
+}
+
+const fetchWizardById = async (id: string): Promise<Wizard> => {
+  const { data } = await axios.get(`${API_BASE}/Wizards/${id}`)
+  return data
+}
+
+export function useWizards() {
+  return useQuery({
+    queryKey: ['wizards'],
+    queryFn: fetchWizards,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useWizard(id: string) {
+  return useQuery({
+    queryKey: ['wizard', id],
+    queryFn: () => fetchWizardById(id),
+    enabled: !!id, // only fetch if id is defined
+    staleTime: 1000 * 60 * 10,
+  })
+}
+
+export function useWizardFromCache(id: string): Wizard | undefined {
+  const queryClient = useQueryClient()
+  const wizards = queryClient.getQueryData<Wizard[]>(['wizards'])
+  return wizards?.find(w => w.id === id)
+}

--- a/src/stores/wizardingWorld.ts
+++ b/src/stores/wizardingWorld.ts
@@ -1,151 +1,17 @@
 import { defineStore } from 'pinia'
 import type { House } from '@/types/House'
-import type { Spell } from '@/types/Spell'
-import type { Elixir } from '@/types/Elixir'
-import type { Ingredient } from '@/types/Ingredient'
-import type { Wizard } from '@/types/Wizard'
-import axios from 'axios'
 
 export const useWizardingWorldStore = defineStore('wizardingWorld', {
   state: () => ({
-    houses: [] as House[],
-    spells: [] as Spell[],
-    ingredients: [] as Ingredient[],
-    elixirs: [] as Elixir[],
-    wizards: [] as Wizard[],
     selectedHouse: null as House | null,
-    loading: {
-      houses: false,
-      spells: false,
-      ingredients: false,
-      elixirs: false,
-      wizards: false,
-    },
-    errors: {
-      houses: null as string | null,
-      spells: null as string | null,
-      ingredients: null as string | null,
-      elixirs: null as string | null,
-      wizards: null as string | null,
-    },
   }),
 
   getters: {
-    getHouse: (state) => {
-      return (houseId: string) => state.houses.find((house: House) => house.id === houseId)
-    },
-    getSpell: (state) => {
-      return (spellId: string) => state.spells.find((spell: Spell) => spell.id === spellId)
-    },
-    getIngredient: (state) => {
-      return (ingredientId: string) =>
-        state.ingredients.find((ingredient: Ingredient) => ingredient.id === ingredientId)
-    },
-    getElixir: (state) => {
-      return (elixirId: string) => state.elixirs.find((elixir: Elixir) => elixir.id === elixirId)
-    },
-    getWizard: (state) => {
-      return (wizardId: string) => state.wizards.find((wizard: Wizard) => wizard.id === wizardId)
-    },
-    isLoading: (state) => {
-      return Object.values(state.loading).some((loading) => loading)
-    },
   },
 
   actions: {
-    async fetchHouses() {
-      this.loading.houses = true
-      this.errors.houses = null
-      try {
-        const response = await axios.get('https://wizard-world-api.herokuapp.com/Houses')
-        this.houses = response.data
-      } catch (error) {
-        this.errors.houses = error instanceof Error ? error.message : 'Failed to fetch houses'
-        throw error
-      } finally {
-        this.loading.houses = false
-      }
-    },
-
-    async fetchSpells() {
-      this.loading.spells = true
-      this.errors.spells = null
-      try {
-        const response = await axios.get('https://wizard-world-api.herokuapp.com/Spells')
-        this.spells = response.data
-      } catch (error) {
-        this.errors.spells = error instanceof Error ? error.message : 'Failed to fetch spells'
-        throw error
-      } finally {
-        this.loading.spells = false
-      }
-    },
-
-    async fetchIngredients() {
-      this.loading.ingredients = true
-      this.errors.ingredients = null
-      try {
-        const response = await axios.get('https://wizard-world-api.herokuapp.com/Ingredients')
-        this.ingredients = response.data
-      } catch (error) {
-        this.errors.ingredients =
-          error instanceof Error ? error.message : 'Failed to fetch ingredients'
-        throw error
-      } finally {
-        this.loading.ingredients = false
-      }
-    },
-
-    async fetchElixirs() {
-      this.loading.elixirs = true
-      this.errors.elixirs = null
-      try {
-        const response = await axios.get('https://wizard-world-api.herokuapp.com/Elixirs')
-        this.elixirs = response.data
-      } catch (error) {
-        this.errors.elixirs = error instanceof Error ? error.message : 'Failed to fetch elixirs'
-        throw error
-      } finally {
-        this.loading.elixirs = false
-      }
-    },
-
-    async fetchWizards() {
-      this.loading.wizards = true
-      this.errors.wizards = null
-      try {
-        const response = await axios.get('https://wizard-world-api.herokuapp.com/Wizards')
-        this.wizards = response.data
-      } catch (error) {
-        this.errors.wizards = error instanceof Error ? error.message : 'Failed to fetch wizards'
-        throw error
-      } finally {
-        this.loading.wizards = false
-      }
-    },
-
-    async fetchAll() {
-      await Promise.allSettled([
-        this.fetchHouses(),
-        this.fetchSpells(),
-        this.fetchIngredients(),
-        this.fetchElixirs(),
-        this.fetchWizards(),
-      ])
-    },
-
     setSelectedHouse(house: House | null) {
       this.selectedHouse = house
-    },
-
-    clearErrors() {
-      this.errors = {
-        houses: null,
-        spells: null,
-        ingredients: null,
-        elixirs: null,
-        wizards: null,
-      }
     },
   },
 })

--- a/src/views/ElixirsView.vue
+++ b/src/views/ElixirsView.vue
@@ -10,10 +10,8 @@ import InputText from 'primevue/inputtext'
 import { ElixirDifficulty } from '@/types/Elixir'
 import type { Elixir } from '@/types/Elixir'
 import VirtualScroller from 'primevue/virtualscroller'
-const store = useWizardingWorldStore()
-const elixirs = computed(() => store.elixirs)
-const loading = false
-
+import { useElixirs } from '@/composables/useElixirs'
+const { data, isLoading, error, refetch } = useElixirs()
 let selectedElixir = {
   id: '',
   name: '',
@@ -76,7 +74,7 @@ const filteredElixirs = computed(() => {
     })
   }
 
-  return elixirs.value.filter((e) => {
+  return data.value?.filter((e) => {
     return (
       e.name.toLowerCase().includes(globalFilters.nameFilter.toLowerCase()) &&
       (globalFilters.difficultyFilter === '' || e.difficulty === globalFilters.difficultyFilter)
@@ -86,7 +84,7 @@ const filteredElixirs = computed(() => {
 
 // Exposing functions to window - bad practice
 window.selectElixirById = function (id) {
-  const elixir = elixirs.value.find((e) => e.id === id)
+  const elixir = data.value.find((e) => e.id === id)
   if (elixir) {
     // Direct assignment instead of using reactive
     selectedElixir = elixir
@@ -102,7 +100,7 @@ window.selectElixirById = function (id) {
 
 window.deleteElixirById = function (id) {
   // Modify the array directly
-  elixirs.value = elixirs.value.filter((e) => e.id !== id)
+  data.value = data.value?.filter((e) => e.id !== id)
 
   // Remove from DOM directly
   const element = document.getElementById('elixir-' + id)
@@ -111,17 +109,15 @@ window.deleteElixirById = function (id) {
   }
 }
 
-const loadElixirs = async () => {
-  try {
-    await store.fetchElixirs()
-  } catch (error) {
-    console.error('Failed to load elixirs:', error)
-  }
-}
+// const loadElixirs = async () => {
+//   try {
+//     await store.fetchElixirs()
+//   } catch (error) {
+//     console.error('Failed to load elixirs:', error)
+//   }
+// }
 onMounted(() => {
-  if (store.spells.length === 0) {
-    loadElixirs()
-  }
+
 })
 
 // Overly verbose watchers
@@ -164,11 +160,6 @@ watch(
   },
 )
 
-// const { data, isLoading, error } = useQuery({
-//   queryKey: ['elixirs'],
-//   queryFn: fetchElixirs,
-// })
-
 // Directly mutating an object
 function selectElixir(elixir) {
   selectedElixir = elixir
@@ -199,7 +190,7 @@ const items = ref([])
 
 function deleteElixir(id) {
   console.log('Deleting elixir', id)
-  elixirs.value = elixirs.value.filter((e) => e.id !== id)
+  data.value = data.value?.filter((e) => e.id !== id)
 }
 </script>
 

--- a/src/views/HouseDetailView.vue
+++ b/src/views/HouseDetailView.vue
@@ -4,9 +4,9 @@
   <div></div>
 </template>
 <script setup lang="ts">
-import { useWizardingWorldStore } from '@/stores'
+import { useHouse } from '@/composables/useHouses'
 import { useRoute } from 'vue-router'
-const wizardingStore = useWizardingWorldStore()
+
 const route = useRoute()
-const house = wizardingStore.getHouse(route.params.id)
+const { data:house , isLoading , error} = useHouse(route.params.id)
 </script>

--- a/src/views/HousesView.vue
+++ b/src/views/HousesView.vue
@@ -1,85 +1,26 @@
 <script setup lang="ts">
-import { ref, reactive, onMounted, watch, onUnmounted } from 'vue'
-import { useQuery } from '@tanstack/vue-query'
+import { onMounted } from 'vue'
 import Card from 'primevue/card'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import Button from 'primevue/button'
-import type { House } from '../types/House'
 import HouseCard from '../components/HouseCard.vue'
-import { useWizardingWorldStore } from '../stores/wizardingWorld'
 
-const wizardingStore = useWizardingWorldStore()
-const loading = ref(false)
-const error = ref(null)
-// const houses = wizardingStore.houses
+import { useHouses } from '@/composables/useHouses'
 
-// const fetchHouses = async () => {
-//   await new Promise((resolve) => setTimeout(resolve, 500))
-//   return houses.value
-// }
-
-// const { data, isLoading, error } = useQuery({
-//   queryKey: ['houses'],
-//   queryFn: fetchHouses,
-// })
-
-// const tableData = reactive({
-//   houses: [],
-//   selectedHouse: null,
-// })
-
-// const lastSelectedHouse = ref<string | null>(null)
-
-// function updateHousePoints(houseId: string, points: number) {
-//   const house = houses.value.find((h) => h.id === houseId)
-//   if (house) {
-//     house.house_points = points
-//   }
-// }
-
-// function selectHouse(house: House) {
-//   tableData.selectedHouse = house
-//   wizardingStore.selectHouse(house.id)
-//   lastSelectedHouse.value = house.name
-// }
-
-// watch(
-//   () => wizardingStore.selectedHouse,
-//   (newHouse) => {
-//     if (newHouse) {
-//       tableData.selectedHouse = houses.value.find((h) => h.id === newHouse.id) || null
-//     }
-//   },
-// )
+const { data, isLoading, error } = useHouses()
 
 onMounted(() => {
   document.title = 'Hogwarts Houses'
-  // if (wizardingStore.houses) {
-  //   houses.value = [...wizardingStore.houses]
-  // }
-  loading.value = true
-  wizardingStore
-    .fetchHouses()
-    .catch((err) => {
-      error.value = err
-    })
-    .finally(() => {
-      loading.value = false
-    })
-})
-
-onUnmounted(() => {
-  // No need to clear the timer as it's not used
 })
 </script>
 
 <template>
   <h1>Houses</h1>
-  <div v-if="loading">Loading...</div>
+  <div v-if="isLoading">Loading...</div>
 
   <div v-else class="grid sm:grid-cols-1 lg:grid-cols-2 gap-4">
-    <div v-for="house in wizardingStore.houses" :key="house.id" class="">
+    <div v-for="house in data" :key="house.id" class="">
       <HouseCard :house="house" />
     </div>
   </div>

--- a/src/views/SpellsView.vue
+++ b/src/views/SpellsView.vue
@@ -4,30 +4,30 @@
       <h1 class="text-3xl font-bold mb-6">Spells</h1>
 
       <!-- Loading State -->
-      <div v-if="store.loading.spells" class="flex justify-center items-center py-8">
+      <div v-if="isLoading" class="flex justify-center items-center py-8">
         <ProgressSpinner />
       </div>
 
       <!-- Error State -->
-      <Message v-else-if="store.errors.spells" severity="error" class="mb-4">
-        {{ store.errors.spells }}
+      <Message v-else-if="error" severity="error" class="mb-4">
+        {{ error }}
         <template #action>
-          <Button text @click="loadSpells" :loading="store.loading.spells" >
+          <Button text @click="refetch" :loading="isLoading" >
             <FontAwesomeIcon icon="fas fa-rotate-right" />
           </Button>
         </template>
       </Message>
 
       <!-- DataTable -->
-      <DataTable v-else v-model:filters="filters" :value="spells" :paginator="true" :rows="10"
-        :rowsPerPageOptions="[5, 10, 20, 50]" :totalRecords="spells.length"
+      <DataTable v-else v-model:filters="filters" :value="data" :paginator="true" :rows="10"
+        :rowsPerPageOptions="[5, 10, 20, 50]" :totalRecords="data.length"
         paginatorTemplate="RowsPerPageDropdown FirstPageLink PrevPageLink CurrentPageReport NextPageLink LastPageLink"
-        currentPageReportTemplate="{first} to {last} of {totalRecords}" :loading="store.loading.spells"
+        currentPageReportTemplate="{first} to {last} of {totalRecords}" :loading="isLoading"
         filterDisplay="menu" :globalFilterFields="['name', 'type', 'incantation']" class="p-datatable-sm" stripedRows
         responsiveLayout="scroll">
         <template #header>
           <div class="flex justify-between items-center">
-            <h2 class="text-xl font-semibold">All Spells ({{ spells.length }})</h2>
+            <h2 class="text-xl font-semibold">All Spells ({{ data.length }})</h2>
             <div class="flex gap-2">
               <Button type="button" outlined @click="clearFilter()">
                 <FontAwesomeIcon icon="fas fa-filter-circle-xmark"></FontAwesomeIcon>
@@ -37,8 +37,8 @@
                 <InputText v-model="filters['global'].value" placeholder="Search spells..." class="w-64" />
               </IconField>
               <Button 
-                @click="loadSpells" 
-                :loading="store.loading.spells" 
+                @click="refetch" 
+                :loading="isLoading" 
                 severity="secondary"
                 outlined >
                   <FontAwesomeIcon icon="fas fa-rotate-right" />
@@ -138,7 +138,7 @@
           <div class="text-center py-8">
             <i class="pi pi-search text-4xl text-gray-400 mb-4"></i>
             <p class="text-gray-500">No spells found</p>
-            <Button label="Load Spells" icon="pi pi-refresh" @click="loadSpells" class="mt-4" />
+            <Button label="Load Spells" icon="pi pi-refresh" @click="refetch" class="mt-4" />
           </div>
         </template>
       </DataTable>
@@ -192,8 +192,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import { useWizardingWorldStore } from '@/stores/wizardingWorld'
+import { ref, onMounted } from 'vue'
 import { FilterMatchMode, FilterOperator } from '@primevue/core/api'
 import { SpellLight, SpellType, type Spell } from '@/types/Spell'
 
@@ -212,10 +211,8 @@ import Dialog from 'primevue/dialog'
 import MultiSelect from 'primevue/multiselect'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import Select from 'primevue/select';
-
-
-const store = useWizardingWorldStore()
-
+import { useSpells } from '@/composables/useSpells'
+const { data, isLoading, error, refetch } = useSpells()
 // Reactive data
 const showSpellDialog = ref(false)
 const selectedSpell = ref<Spell | null>(null)
@@ -243,16 +240,7 @@ const spellLights = Object.values(SpellLight).map((value) => ({
   label: value,
   value,
 }))
-// Computed
-const spells = computed(() => store.spells)
-// Methods
-const loadSpells = async () => {
-  try {
-    await store.fetchSpells()
-  } catch (error) {
-    console.error('Failed to load spells:', error)
-  }
-}
+
 const clearFilter = () => {
   initFilters();
 };
@@ -287,9 +275,6 @@ const truncateText = (text: string, maxLength: number): string => {
 // Lifecycle
 onMounted(() => {
    document.title = 'Stunning Spells'
-  if (store.spells.length === 0) {
-    loadSpells()
-  }
 })
 </script>
 

--- a/src/views/WizardsView.vue
+++ b/src/views/WizardsView.vue
@@ -4,15 +4,15 @@
       <h1 class="text-3xl font-bold mb-6">Wizards</h1>
 
       <!-- Loading State -->
-      <div v-if="store.loading.wizards" class="flex justify-center items-center py-8">
+      <div v-if="isLoading" class="flex justify-center items-center py-8">
         <ProgressSpinner />
       </div>
 
       <!-- Error State -->
-      <Message v-else-if="store.errors.wizards" severity="error" class="mb-4">
-        {{ store.errors.wizards }}
+      <Message v-else-if="error" severity="error" class="mb-4">
+        {{ error }}
         <template #action>
-          <Button icon="pi pi-refresh" text @click="loadWizards" :loading="store.loading.wizards" />
+          <Button icon="pi pi-refresh" text @click="refetch" :loading="isLoading" />
         </template>
       </Message>
 
@@ -20,14 +20,14 @@
       <DataTable
         v-else
         v-model:filters="filters"
-        :value="wizards"
+        :value="data"
         :paginator="true"
         :rows="10"
         :rowsPerPageOptions="[5, 10, 20, 50]"
-        :totalRecords="wizards.length"
+        :totalRecords="data.length"
         paginatorTemplate="RowsPerPageDropdown FirstPageLink PrevPageLink CurrentPageReport NextPageLink LastPageLink"
         currentPageReportTemplate="{first} to {last} of {totalRecords}"
-        :loading="store.loading.spells"
+        :loading="isLoading"
         filterDisplay="menu"
         :globalFilterFields="['firstName', 'lastName']"
         class="p-datatable-sm"
@@ -36,7 +36,7 @@
       >
         <template #header>
           <div class="flex justify-between items-center">
-            <h2 class="text-xl font-semibold">All Wizards ({{ wizards.length }})</h2>
+            <h2 class="text-xl font-semibold">All Wizards ({{ data.length }})</h2>
             <div class="flex gap-2">
               <div class="p-input-icon-left">
                 <!-- <InputIcon class="pi pi-search" /> -->
@@ -48,8 +48,8 @@
                 />
               </div>
               <Button
-                @click="loadWizards"
-                :loading="store.loading.wizards"
+                @click="refetch"
+                :loading="isLoading"
                 severity="secondary"
                 outlined
               >
@@ -141,7 +141,6 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useWizardingWorldStore } from '@/stores/wizardingWorld'
 import { FilterMatchMode } from '@primevue/core/api'
 import type { Wizard } from '@/types/Wizard'
 
@@ -157,8 +156,9 @@ import Badge from 'primevue/badge'
 
 import Dialog from 'primevue/dialog'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { useWizards } from '@/composables/useWizards'
 
-const store = useWizardingWorldStore()
+const { data, isLoading, error, refetch } = useWizards()
 
 // Reactive data
 const showWizardDialog = ref(false)
@@ -168,18 +168,6 @@ const selectedWizard = ref<Wizard | null>(null)
 const filters = ref({
   global: { value: null, matchMode: FilterMatchMode.CONTAINS },
 })
-
-// Computed
-const wizards = computed(() => store.wizards)
-
-// Methods
-const loadWizards = async () => {
-  try {
-    await store.fetchWizards()
-  } catch (error) {
-    console.error('Failed to load wizards:', error)
-  }
-}
 
 const viewWizard = (wizard: Wizard) => {
   selectedWizard.value = wizard
@@ -198,10 +186,7 @@ const truncateText = (text: string, maxLength: number): string => {
 
 // Lifecycle
 onMounted(() => {
-   document.title = 'Powerful Wizards'
-  if (store.wizards.length === 0) {
-    loadWizards()
-  }
+  document.title = 'Powerful Wizards'
 })
 </script>
 


### PR DESCRIPTION
Move all API requests to composables. Benefits are

- Reusability
- Separation of concerns and better maintainability
- TanStack Query handles all the caching and refetching of data making life a lot easier 

Store only to be used for Global UI configs and Auth in the future